### PR TITLE
Add ability to search grams for greater flexibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
-FuzzyFind
-===========
+## FuzzyFind
 
-FuzzyFind is a matching algorithm for filtering and ranking a list based on partial user input. 
+FuzzyFind is a matching algorithm for filtering and ranking a list based on
+partial user input.
 
-eg: 
+### API
+
+`array fuzzyfind ( string $query , array $collection [, object $options ])`
+
+#### All Options
+
+* `accessor` *function*: Function that transforms your items into strings.
+* `precision` *number*: How precise you want your search to be, between 0 and 1.
+
+### Usage
 
 ```js
 var fuzzy = require('fuzzyfind')
@@ -36,10 +45,39 @@ var collection = [
     { name: 'accounts.txt', size: '10kb'},
 ]
 
-console.log(fuzzy('djmi', collection, function(obj) {
+function accessorFn (obj) {
     return obj.name
-}))
+}
+console.log(fuzzy('djmi', collection, { accessor: accessorFn }))
 [ 'django_migrations.py', 'django_admin_log.py' ]
 ```
 
-The algorithm used is a direct translation from Python to JS from this blog: http://blog.amjith.com/fuzzyfinder-in-10-lines-of-python.
+Precision can also be defined in your search, if you want to be more inclusive
+in your results. The lower your precision the more matches you get, with a
+precision of 1 you want to match the full word, while a precision of 0 would be
+matching any letter in your query.
+
+The size of the match is taking into account, so having less precision would
+just be adding more results to the `end` of your results.
+
+To define precision:
+
+```js
+var fuzzy = require('fuzzyfind')
+var collection = [
+    'migrations.py',
+    'django_migrations.py',
+    'django_admin_log.py',
+    'api_user.doc',
+    'user_group.doc',
+    'users.txt',
+    'accounts.txt'
+]
+
+console.log(fuzzy('djmi', collection, { precision: 0.5 }))
+[ 'django_migrations.py', 'django_admin_log.py', 'migrations.py' ]
+```
+
+The algorithm was influenced by a blog post about [fuzzy finding][blog].
+
+[blog]: http://blog.amjith.com/fuzzyfinder-in-10-lines-of-python

--- a/generateGrams.js
+++ b/generateGrams.js
@@ -1,0 +1,16 @@
+module.exports = function generateGrams (word, precision) {
+  var wordLength = word.length
+  var smallestGram = Math.ceil(wordLength * precision) || 1
+  var grams = []
+  var gramLength = wordLength
+  while (gramLength >= smallestGram) {
+    var start = 0
+    var end = wordLength - gramLength
+    for (start; start <= end;start++) {
+      var gram = word.substr(start, gramLength)
+      if (grams.indexOf(gram) === -1) grams.push(gram)
+    }
+    gramLength--
+  }
+  return grams
+}

--- a/index.js
+++ b/index.js
@@ -1,29 +1,40 @@
 var search = require('./search')
+var generateGrams = require('./generateGrams')
 
-module.exports = function fuzzyfind (input, collection, accessor) {
+module.exports = function fuzzyfind (input, collection, options) {
   if (typeof input !== 'string' || input === '') {
     return collection
   }
+  options = options || {}
+  var accessor = options.accessor || function(item) { return item }
+  var precision = options.precision === undefined ? 1 : options.precision
   var suggestions = []
-  if (!accessor) {
-    accessor = function(item) {
-      return item
-    }
-  }
+
+  var grams = generateGrams(input, precision)
   collection.forEach(function (item) {
-    const searchableItem = accessor(item)
-    var match = search(searchableItem).for(input)
-    if (match.found) {
-      suggestions.push({
-        length: match.end - match.start,
-        start: match.start,
-        searchableItem: searchableItem,
-        item: item
-      })
-    }
+    var searchableItem = accessor(item)
+    grams.find(function (gram) {
+      var match = search(searchableItem).for(gram)
+      if (match.found) {
+        suggestions.push({
+          gram: gram,
+          length: match.end - match.start,
+          start: match.start,
+          searchableItem: searchableItem,
+          item: item
+        })
+      }
+      return match.found
+    })
   })
 
   suggestions.sort(function (a, b) {
+    if (a.gram.length > b.gram.length) {
+      return -1
+    }
+    if (a.gram.length < b.gram.length) {
+      return 1
+    }
     if (a.length > b.length) {
       return 1
     }
@@ -48,8 +59,4 @@ module.exports = function fuzzyfind (input, collection, accessor) {
   return suggestions.map(function (item) {
     return item.item
   })
-}
-
-function escapeRegExp (string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/perf/index.js
+++ b/perf/index.js
@@ -3,7 +3,8 @@ var test = require('tape')
 
 test('Large item', function (t) {
   var totalDuration = 0, i
-  for (i = 0;i<500;i++) {
+  var iterations = 500
+  for (i = 0;i<iterations;i++) {
     var subset = [
       'Set Versionjavascript:(function()%7Bvar product%3Dwindow.prompt(%27What product%3F%27,%27filterable_errors%27)%3Bvar key %3D %27use_%27 %2B product %2B %27_version%27%3Bvar version%3Dwindow.prompt(%27What version%3F%27,%27hot%27)%3Bvar queries%3Dwindow.location.search.split(/%5B%5C%3F%7C%26%5D%2B/)%3Bqueries%3Dqueries.filter((query)%3D>%7Breturn query%7D)%3Bvar alreadyExists%3Dfalse%3Bqueries.forEach((query,index)%3D>%7Bif(query.includes(key))%7BalreadyExists%3Dtrue%3BqueryParts%3Dquery.split(%27%3D%27)%3BqueryParts%5B1%5D%3Dversion%3Bqueries%5Bindex%5D%3DqueryParts.join(%27%3D%27)%3B%7D%7D)%3Bif(!alreadyExists)%7Bqueries.push(key%2B%27%3D%27%2Bversion)%3B%7Dif(queries.length%3D%3D%3D1)%7Bwindow.location.search%3Dqueries%5B0%5D%3B%7Delse%7Bwindow.location.search%3Dqueries.join(%27%26%27)%3B%7D%7D)()%3B'
     ]
@@ -13,5 +14,6 @@ test('Large item', function (t) {
     var end = new Date()
     totalDuration += end - start
   }
-  t.ok(totalDuration < 10, 'wanted ' + totalDuration + 'ms to be less than 10ms')
+  var maxTime = iterations * 0.05 // 0.05ms per result
+  t.ok(totalDuration < maxTime, 'wanted ' + totalDuration + 'ms to be less than ' + maxTime + 'ms')
 })

--- a/test/fuzzyfind.js
+++ b/test/fuzzyfind.js
@@ -25,6 +25,11 @@ test('Simple fuzzy search', function (t) {
   t.deepEqual(fuzzy('djmi', collection), ['django_migrations.py', 'django_admin_log.py'])
 })
 
+test('readme precision example', function (t) {
+  t.plan(1)
+  t.deepEqual(fuzzy('djmi', collection, { precision: 0.5 }), ['django_migrations.py', 'django_admin_log.py', 'migrations.py'])
+})
+
 test('Fuzzy Match Ranking', function (t) {
   t.plan(1)
   t.deepEqual(fuzzy('mi', collection), ['migrations.py', 'django_migrations.py', 'django_admin_log.py'])
@@ -40,12 +45,43 @@ test('Uses Accessor', function (t) {
   var objCollection = collection.map(function(name) {
     return { name: name }
   })
-  t.deepEqual(fuzzy('mi', objCollection, function(item) {
+  t.deepEqual(fuzzy('mi', objCollection, { accessor: function(item) {
     return item.name
-  }), [{name: 'migrations.py'}, {name: 'django_migrations.py'}, {name: 'django_admin_log.py'}])
+  }}), [{name: 'migrations.py'}, {name: 'django_migrations.py'}, {name: 'django_admin_log.py'}])
 })
 
 test('Fuzzy Match non-greedy', function (t) {
   t.plan(1)
   t.deepEqual(fuzzy('user', collection), ['user_group.doc', 'users.txt', 'api_user.doc'])
+})
+
+// Matching doc
+test('Default precision searches', function (t) {
+  t.plan(1)
+  t.deepEqual(fuzzy('doc', collection), ['api_user.doc', 'user_group.doc'])
+})
+
+// Matching doc
+test('Full precision searches', function (t) {
+  t.plan(1)
+  t.deepEqual(fuzzy('doc', collection, { precision: 1 }), ['api_user.doc', 'user_group.doc'])
+})
+
+// Matching doc, do, oc
+test('Half precision searches', function (t) {
+  t.plan(1)
+  t.deepEqual(fuzzy('doc', collection, { precision: 0.5 }), ['api_user.doc', 'user_group.doc', 'django_admin_log.py', 'django_migrations.py'])
+})
+
+// Matching any letter in your query
+test('No precision searches', function (t) {
+  t.plan(1)
+  t.deepEqual(fuzzy('doc', collection, { precision: 0 }), [
+    'api_user.doc',
+    'user_group.doc',
+    'django_admin_log.py',
+    'django_migrations.py',
+    'accounts.txt',
+    'migrations.py'
+  ])
 })

--- a/test/generateGrams.js
+++ b/test/generateGrams.js
@@ -1,0 +1,37 @@
+var test = require('tape')
+var generateGrams = require('../generateGrams')
+
+test('odd character word', function (t) {
+  t.plan(1)
+  var result = generateGrams('hello', 0.5)
+  var expected = ['hello', 'hell', 'ello', 'hel', 'ell', 'llo']
+  t.deepEqual(result, expected)
+})
+
+test('even character word', function (t) {
+  t.plan(1)
+  var result = generateGrams('food', 0.5)
+  var expected = ['food', 'foo', 'ood', 'fo', 'oo', 'od']
+  t.deepEqual(result, expected)
+})
+
+test('full precision', function (t) {
+  t.plan(1)
+  var result = generateGrams('food', 1)
+  var expected = ['food']
+  t.deepEqual(result, expected)
+})
+
+test('duplicates', function (t) {
+  t.plan(1)
+  var result = generateGrams('ooo', 0)
+  var expected = ['ooo', 'oo', 'o']
+  t.deepEqual(result, expected)
+})
+
+test('no precision', function (t) {
+  t.plan(1)
+  var result = generateGrams('food', 0)
+  var expected = ['food', 'foo', 'ood', 'fo', 'oo', 'od', 'f', 'o', 'd']
+  t.deepEqual(result, expected)
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./fuzzyfind')
 require('./search')
+require('./generateGrams')


### PR DESCRIPTION
The [whitespace insensitive diff](https://github.com/amjith/fuzzyfind/pull/10/files?w=true) is a better view.

This allows you to specify a precision on how accurate you want your search. Of course the less accurate the less likely it's relevant to the user.

However, it takes into account the matched `gram` when sorting, so changing from a precision of `1` to `0.5` you'll only be adding items to the END of your list.
