### PR TITLE
Fix "An export assignment cannot be used in a module with other exported elements."

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-export = fuzzyfind
+export default fuzzyfind
 type Options = {
   accessor?: (a: any) => string
   precision?: number


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18403742/159957656-133ef055-6415-485f-b6d6-51de8c4ec598.png)
TypeScript doesn't like this for some reason, but everything seems to work as expected if I change `export = fuzzyfind` to `export default fuzzyfind`.